### PR TITLE
don't free interrupts that haven't been set up

### DIFF
--- a/platforms/esp/32/clockless_esp32.h
+++ b/platforms/esp/32/clockless_esp32.h
@@ -153,7 +153,7 @@ protected:
     virtual void showPixels(PixelController<RGB_ORDER> & pixels)
     {
         mWait.wait();
-	esp_intr_alloc(ETS_RMT_INTR_SOURCE, 0, handleInterrupt, this, &mRMT_intr_handle);
+	esp_err_t intr_setup = esp_intr_alloc(ETS_RMT_INTR_SOURCE, 0, handleInterrupt, this, &mRMT_intr_handle);
 
 	// -- Initialize the local state, save a pointer to the pixel data
 	local_pixels = &pixels;
@@ -177,7 +177,7 @@ protected:
 	vSemaphoreDelete(mTX_sem);
 	mTX_sem = NULL;
 
-	esp_intr_free(mRMT_intr_handle);
+	if (intr_setup == ESP_OK) esp_intr_free(mRMT_intr_handle);
 	mWait.mark();
     }
 


### PR DESCRIPTION
fixes some random reboots for me where FastLED.show() would throw an exception.

i observed some exceptions from FastLED.show() (only after some runtime):
> Guru Meditation Error: Core  1 panic'ed (LoadProhibited)
> . Exception was unhandled.
> Backtrace:
> 0x400d63a9: esp_intr_free at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/esp32/./intr_alloc.c:768
> 0x400d1fdc: ClocklessController<21, 60, 150, 90, (EOrder)66, 0, false, 5>::showPixels(PixelController<(EOrder)66, 1, 4294967295u>&) at .piolibdeps/FastLED/controller.h:170
> [...]

until now i surrounded show() with try...catch (also add -fexceptions to the build_flags). i think this pull request is finally the proper way to avoid these exceptions.