### PR TITLE
Fix allocate by zero

### DIFF
--- a/src/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/src/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -366,7 +366,7 @@ void ESP32RMTController::initPulseBuffer(int size_in_bytes)
 {
     if (mBuffer == 0) {
         // -- Each byte has 8 bits, each bit needs a 32-bit RMT item
-        int size = size_in_bytes * 8 * 4;
+        mBufferSize size = size_in_bytes * 8 * 4;
 
         mBuffer = (rmt_item32_t *) calloc( mBufferSize, sizeof(rmt_item32_t));
     }

--- a/src/platforms/esp/32/clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/clockless_rmt_esp32.h
@@ -204,7 +204,7 @@ private:
     // -- Buffer to hold all of the pulses. For the version that uses
     //    the RMT driver built into the ESP core.
     rmt_item32_t * mBuffer;
-    uint16_t       mBufferSize;
+    uint16_t       mBufferSize; // bytes
     int            mCurPulse;
 
     // -- Make sure we can't call show() too quickly


### PR DESCRIPTION
My compiler caught size as an uninitialized variable, which leads to understanding that mBufferSize is never set.
Not tested, this code is only used when internal RMT is used, and I haven't tried that yet, but this has to be better than the current.